### PR TITLE
Streamline executive dashboard widgets

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,541 +1,166 @@
-const siteConfig = {
-  hero: {
-    name: 'Caleb Drew',
-    greeting: "Hello, I'm",
-    tagline:
-      'Manufacturing analytics leader turning ERP, shop floor, and macro signals into real-time intelligence.',
-    resumeUrl: 'Caleb_Drew_Resume.pdf',
-    contactMailto: 'mailto:calebldrew@gmail.com?subject=Let%27s build intelligent operations',
-    yearsExperience: 4,
-  },
-  tools: [
-    { name: 'Python', logo: 'https://cdn.simpleicons.org/python/3776AB' },
-    { name: 'SQL Server', logo: 'https://cdn.simpleicons.org/microsoftsqlserver/CC2927' },
-    { name: 'Power BI', logo: 'https://cdn.simpleicons.org/powerbi/F2C811' },
-    { name: 'Microsoft Fabric', logo: 'https://cdn.simpleicons.org/microsoft/6366F1' },
-    { name: 'Azure', logo: 'https://cdn.simpleicons.org/microsoftazure/0089D6' },
-    { name: 'Airbyte', logo: 'https://cdn.simpleicons.org/airbyte/615EFF' },
-    { name: 'Oracle', logo: 'https://cdn.simpleicons.org/oracle/F80000' },
-    { name: 'SAP', logo: 'https://cdn.simpleicons.org/sap/0FAAFF' },
-    { name: 'Microsoft Excel', logo: 'https://cdn.simpleicons.org/microsoftexcel/217346' },
-    { name: 'Lean Six Sigma', logo: 'https://cdn.simpleicons.org/sixsigma/0033A0' },
-  ],
-  skills: [
-    {
-      title: 'Operational Analytics & Lean Manufacturing',
-      description:
-        'Redesigned KPI reporting for Hultec (S&B), moving global operations from manual spreadsheets to real-time Fabric dashboards with 95% adoption.',
-      resumeLink: 'Hultec (S&B) — Analyst (Internal Consultant)',
-    },
-    {
-      title: 'Predictive Demand & Inventory Modeling',
-      description:
-        'Implemented seasonal demand models that cut emergency production by 10% and reduced stockouts to 5%, protecting service levels across plants.',
-      resumeLink: 'Hultec (S&B) — Analyst (Internal Consultant)',
-    },
-    {
-      title: 'Pricing & Margin Intelligence',
-      description:
-        'Delivered data-driven pricing analytics at Distribution International, reducing material cost variance by $75K and boosting pricing accuracy 15%.',
-      resumeLink: 'Distribution International — Industrial Engineer / Data Analyst',
-    },
-    {
-      title: 'Automated BI & ERP Integration',
-      description:
-        'Unified Oracle ERP and Microsoft Fabric data models so daily reporting runs in minutes instead of hours, saving eight analyst-hours per week.',
-      resumeLink: 'Distribution International — Industrial Engineer / Data Analyst',
-    },
-    {
-      title: 'Executive Storytelling & Decision Enablement',
-      description:
-        'Partnered with leadership to rebuild ERP + shop floor reporting, eliminating 30% of manual data entry errors while aligning executives on a $2M expansion plan.',
-      resumeLink: 'Hultec (S&B) — Analyst (Internal Consultant)',
-    },
-  ],
-  resume: [
-    {
-      role: 'Analyst (Internal Consultant)',
-      company: 'Hultec (S&B)',
-      dates: 'Dec 2024 – Present',
-      highlights: [
-        'Launched live KPI suites (AP terms, inventory turns, backorders) spanning three continents and shrinking manual reporting to near zero.',
-        'Connected Microsoft Fabric lakehouses with Power BI to cut executive prep time from 3 days to under 1 hour.',
-        'Built market valuation modeling blending World Bank signals with sales data to size a 12% growth opportunity supporting a $2M expansion ask.',
-      ],
-    },
-    {
-      role: 'Industrial Engineer / Data Analyst',
-      company: 'Distribution International (TopBuild)',
-      dates: 'Sep 2023 – Nov 2024',
-      highlights: [
-        'Automated SQL + Oracle ERP refreshes, saving 8 analyst hours per week and improving reporting reliability.',
-        'Drove $75K reduction in material cost variance while improving pricing accuracy by 15% across 700K+ SKUs.',
-        'Embedded Lean improvements across supply chain analytics, partnering with ops leaders to modernize pricing visibility.',
-      ],
-    },
-  ],
-};
-
-const fredConfig = {
-  seriesId: 'CPIAUCSL',
-  title: 'Consumer Price Index for All Urban Consumers: All Items in U.S. City Average',
-  frequency: 'Monthly',
-  provider: 'Federal Reserve Bank of St. Louis (FRED)',
-  window: 120, // last ten years of monthly data
-};
-
-const apiSnippet = `const seriesId = '${fredConfig.seriesId}';
-const FRED_KEY = localStorage.getItem('fred-key');
-fetch(` +
-  '`https://api.stlouisfed.org/fred/series/observations?series_id=${seriesId}&api_key=${FRED_KEY}&file_type=json`' +
-  `)
-  .then((r) => r.json())
-  .then((d) => {
-    const observations = d.observations.slice(-${fredConfig.window});
-    // feed visuals + Holt-Winters forecast
-  });`;
-
-const charts = {
-  hero: null,
-  visual: null,
-  forecast: null,
-};
-
-let fredKey = '';
-let fredObservations = [];
-
-document.addEventListener('DOMContentLoaded', () => {
-  initializeHero();
-  renderTools();
-  renderSkills();
-  renderResume();
-  renderApiMetadata();
-  attachEvents();
-  tryLoadStoredKey();
+const formatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0,
 });
 
-function initializeHero() {
-  const hero = siteConfig.hero;
-  document.getElementById('hero-name').textContent = hero.name;
-  document.getElementById('hero-greeting').textContent = hero.greeting;
-  document.getElementById('hero-tagline').textContent = hero.tagline;
-  document.getElementById('statYears').textContent = hero.yearsExperience.toString();
-  document.getElementById('download-resume').addEventListener('click', () => {
-    const link = document.createElement('a');
-    link.href = hero.resumeUrl;
-    link.target = '_blank';
-    link.rel = 'noopener';
-    if (!/^https?:/i.test(hero.resumeUrl)) {
-      link.download = hero.resumeUrl.split('/').pop() || 'Caleb_Drew_Resume.pdf';
-    }
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-  });
-  document.getElementById('contact-me').addEventListener('click', () => {
-    window.location.href = hero.contactMailto;
-  });
-}
+const monthFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  year: 'numeric',
+});
 
-function renderTools() {
-  const grid = document.getElementById('toolGrid');
-  grid.innerHTML = '';
-  siteConfig.tools.forEach((tool) => {
-    const card = document.createElement('div');
-    card.className = 'tool-card';
-    const img = document.createElement('img');
-    img.alt = `${tool.name} logo`;
-    img.loading = 'lazy';
-    img.src = tool.logo;
-    img.onerror = () => {
-      const fallback = document.createElement('span');
-      fallback.className = 'tool-fallback';
-      fallback.textContent = tool.name.charAt(0);
-      img.replaceWith(fallback);
-    };
-    const label = document.createElement('span');
-    label.textContent = tool.name;
-    card.appendChild(img);
-    card.appendChild(label);
-    grid.appendChild(card);
-  });
-}
+const actualHistory = [
+  118, 126, 130, 142, 150, 158, 155, 149, 140, 134, 128, 122, // 2021
+  125, 132, 138, 150, 162, 170, 168, 160, 152, 146, 140, 135, // 2022
+  138, 144, 152, 164, 176, 185, 182, 174, 166, 158, 150, 144, // 2023
+];
 
-function renderSkills() {
-  const container = document.getElementById('skillList');
-  container.innerHTML = '';
-  siteConfig.skills.forEach((skill) => {
-    const card = document.createElement('article');
-    card.className = 'skill-card';
-    const title = document.createElement('h3');
-    title.textContent = skill.title;
-    const desc = document.createElement('p');
-    desc.textContent = skill.description;
-    const tag = document.createElement('span');
-    tag.className = 'resume-tag';
-    tag.textContent = skill.resumeLink;
-    card.appendChild(title);
-    card.appendChild(desc);
-    card.appendChild(tag);
-    container.appendChild(card);
-  });
-}
+const holtWintersForecast = [
+  147, 154, 162, 174, 186, 194, 190, 182, 174, 166, 158, 152, // 2024 forecast
+];
 
-function renderResume() {
-  const timeline = document.getElementById('resumeTimeline');
-  timeline.innerHTML = '';
-  siteConfig.resume.forEach((entry) => {
-    const article = document.createElement('article');
-    article.className = 'resume-card';
-    const header = document.createElement('header');
-    const role = document.createElement('h3');
-    role.textContent = entry.role;
-    const company = document.createElement('p');
-    company.className = 'resume-company';
-    company.textContent = `${entry.company} · ${entry.dates}`;
-    header.appendChild(role);
-    header.appendChild(company);
-    const list = document.createElement('ul');
-    entry.highlights.forEach((highlight) => {
-      const li = document.createElement('li');
-      li.textContent = highlight;
-      list.appendChild(li);
-    });
-    article.appendChild(header);
-    article.appendChild(list);
-    timeline.appendChild(article);
-  });
-}
+const totalMonths = actualHistory.length + holtWintersForecast.length; // 48
+const labels = Array.from({ length: totalMonths }, (_, index) => {
+  const date = new Date(Date.UTC(2021, 0, 1));
+  date.setUTCMonth(date.getUTCMonth() + index);
+  return monthFormatter.format(date);
+});
 
-function renderApiMetadata() {
-  const apiList = document.getElementById('apiList');
-  apiList.innerHTML = '';
-  const items = [
-    {
-      label: fredConfig.title,
-      value: `Series ID: ${fredConfig.seriesId}`,
-      link: 'https://fred.stlouisfed.org/series/CPIAUCSL',
-    },
-    {
-      label: 'Microsoft Fabric Lakehouse',
-      value: 'Production + shop floor data model',
-    },
-    {
-      label: 'Oracle & SAP ERP Exports',
-      value: 'Pricing, inventory, and vendor terms feeds',
-    },
-  ];
-  items.forEach((item) => {
-    const li = document.createElement('li');
-    li.className = 'api-item';
-    const heading = document.createElement('h4');
-    heading.textContent = item.label;
-    const meta = document.createElement('p');
-    meta.textContent = item.value;
-    li.appendChild(heading);
-    li.appendChild(meta);
-    if (item.link) {
-      const anchor = document.createElement('a');
-      anchor.href = item.link;
-      anchor.target = '_blank';
-      anchor.rel = 'noopener';
-      anchor.textContent = 'View documentation';
-      li.appendChild(anchor);
-    }
-    apiList.appendChild(li);
-  });
-  document.getElementById('apiSnippet').textContent = apiSnippet;
-}
+const actualSeries = Array.from({ length: totalMonths }, (_, index) =>
+  index < actualHistory.length ? actualHistory[index] : null,
+);
 
-function attachEvents() {
-  document.getElementById('loadFred').addEventListener('click', () => {
-    const inputKey = document.getElementById('fredKeyInput').value.trim();
-    if (!inputKey) {
-      setApiStatus('Please enter a FRED API key to continue.', 'warn');
-      return;
-    }
-    fredKey = inputKey;
-    localStorage.setItem('fred-key', fredKey);
-    loadFredData();
-  });
-}
+const forecastSeries = Array.from({ length: totalMonths }, (_, index) =>
+  index >= actualHistory.length ? holtWintersForecast[index - actualHistory.length] : null,
+);
 
-function tryLoadStoredKey() {
-  try {
-    const stored = localStorage.getItem('fred-key');
-    if (stored) {
-      fredKey = stored;
-      document.getElementById('fredKeyInput').value = fredKey;
-      loadFredData();
-    }
-  } catch (error) {
-    console.warn('Local storage unavailable', error);
-  }
-}
+const minSeries = forecastSeries.map((value) =>
+  value == null ? null : Math.round(value * 0.92),
+);
+const maxSeries = forecastSeries.map((value) =>
+  value == null ? null : Math.round(value * 1.08),
+);
 
-async function loadFredData() {
-  setApiStatus('Syncing data from FRED…', 'info');
-  if (!fredKey) {
-    setApiStatus('No FRED API key detected. Please enter it above.', 'warn');
-    return;
-  }
-  const url = new URL('https://api.stlouisfed.org/fred/series/observations');
-  url.searchParams.set('series_id', fredConfig.seriesId);
-  url.searchParams.set('api_key', fredKey);
-  url.searchParams.set('file_type', 'json');
-  url.searchParams.set('observation_start', '2014-01-01');
-  try {
-    const response = await fetch(url.toString());
-    if (!response.ok) throw new Error(`FRED responded with ${response.status}`);
-    const data = await response.json();
-    if (!Array.isArray(data.observations)) throw new Error('Unexpected response payload');
-    fredObservations = data.observations
-      .filter((d) => d.value !== '.' && d.value !== null)
-      .slice(-fredConfig.window)
-      .map((row) => ({
-        date: row.date.slice(0, 10),
-        value: Number(row.value),
-      }));
-    if (!fredObservations.length) throw new Error('No observations returned.');
-    updateHeroCard();
-    updateVisualChart();
-    updateForecastChart();
-    setApiStatus('FRED data refreshed successfully.', 'success');
-  } catch (error) {
-    console.error(error);
-    setApiStatus(`Unable to load FRED data: ${error.message}`, 'error');
-  }
-}
+const latestForecast = holtWintersForecast[holtWintersForecast.length - 1];
+const suggestedMin = Math.round(latestForecast * 0.92);
+const suggestedMax = Math.round(latestForecast * 1.08);
 
-function setApiStatus(message, tone) {
-  const status = document.getElementById('apiStatus');
-  status.textContent = message;
-  status.dataset.tone = tone;
-}
+document.addEventListener('DOMContentLoaded', () => {
+  const ctx = document.getElementById('productionChart');
 
-function updateHeroCard() {
-  if (!fredObservations.length) return;
-  const latest = fredObservations[fredObservations.length - 1];
-  const priorYear = fredObservations.findIndex((row) => row.date === offsetMonths(latest.date, -12));
-  const changeElement = document.getElementById('latestCpiChange');
-  document.getElementById('latestCpiValue').textContent = `${latest.value.toFixed(1)} index pts`;
-  if (priorYear > -1) {
-    const delta = latest.value - fredObservations[priorYear].value;
-    const pct = (delta / fredObservations[priorYear].value) * 100;
-    const direction = delta >= 0 ? '▲' : '▼';
-    changeElement.textContent = `${direction} ${pct.toFixed(2)}% vs LY`;
-    changeElement.className = delta >= 0 ? 'positive' : 'negative';
-  } else {
-    changeElement.textContent = '';
-  }
-  const labels = fredObservations.slice(-36).map((row) => row.date);
-  const values = fredObservations.slice(-36).map((row) => row.value);
-  const ctx = document.getElementById('heroSparkline');
-  if (charts.hero) {
-    charts.hero.data.labels = labels;
-    charts.hero.data.datasets[0].data = values;
-    charts.hero.update();
-  } else {
-    charts.hero = new Chart(ctx, {
+  if (ctx) {
+    new Chart(ctx, {
       type: 'line',
       data: {
         labels,
         datasets: [
           {
-            data: values,
-            borderColor: 'rgba(100, 230, 209, 0.8)',
-            backgroundColor: 'rgba(100, 230, 209, 0.25)',
-            fill: true,
-            tension: 0.3,
+            label: 'Actual production',
+            data: actualSeries,
+            borderColor: '#7a8bff',
+            backgroundColor: 'rgba(122, 139, 255, 0.2)',
+            borderWidth: 3,
             pointRadius: 0,
+            tension: 0.35,
+            spanGaps: true,
+          },
+          {
+            label: 'Holt-Winters forecast',
+            data: forecastSeries,
+            borderColor: '#4bc4b8',
+            borderWidth: 3,
+            borderDash: [8, 6],
+            pointRadius: 0,
+            tension: 0.35,
+            spanGaps: true,
+          },
+          {
+            label: 'Min guardrail',
+            data: minSeries,
+            borderColor: 'rgba(255, 255, 255, 0.45)',
+            borderWidth: 2,
+            borderDash: [4, 6],
+            pointRadius: 0,
+            tension: 0.35,
+            spanGaps: true,
+          },
+          {
+            label: 'Max guardrail',
+            data: maxSeries,
+            borderColor: 'rgba(255, 255, 255, 0.45)',
+            borderWidth: 2,
+            borderDash: [4, 6],
+            pointRadius: 0,
+            tension: 0.35,
+            spanGaps: true,
           },
         ],
       },
       options: {
         responsive: true,
         maintainAspectRatio: false,
-        plugins: { legend: { display: false }, tooltip: { enabled: false } },
-        scales: { x: { display: false }, y: { display: false } },
-      },
-    });
-  }
-  document.getElementById('heroSparklineNote').textContent = `Latest update: ${latest.date}`;
-}
-
-function updateVisualChart() {
-  if (!fredObservations.length) return;
-  const labels = fredObservations.map((row) => row.date);
-  const values = fredObservations.map((row) => row.value);
-  const ctx = document.getElementById('visualChart');
-  if (!charts.visual) {
-    charts.visual = new Chart(ctx, {
-      type: 'line',
-      data: {
-        labels,
-        datasets: [
-          {
-            label: 'CPI (Index 1982–84=100)',
-            data: values,
-            borderColor: 'rgba(92, 108, 255, 0.9)',
-            backgroundColor: 'rgba(92, 108, 255, 0.15)',
-            tension: 0.2,
-            fill: true,
-          },
-        ],
-      },
-      options: {
-        responsive: true,
-        plugins: {
-          legend: { position: 'bottom' },
-          tooltip: { mode: 'index', intersect: false },
-        },
         scales: {
-          x: { ticks: { maxTicksLimit: 10 } },
-          y: { title: { display: true, text: 'Index (1982–84=100)' } },
+          x: {
+            grid: {
+              color: 'rgba(255, 255, 255, 0.05)',
+            },
+            ticks: {
+              maxRotation: 0,
+              autoSkip: true,
+              maxTicksLimit: 8,
+            },
+          },
+          y: {
+            grid: {
+              color: 'rgba(255, 255, 255, 0.08)',
+            },
+            ticks: {
+              callback: (value) => `${value}`,
+            },
+          },
         },
-      },
-    });
-  } else {
-    charts.visual.data.labels = labels;
-    charts.visual.data.datasets[0].data = values;
-    charts.visual.update();
-  }
-  const yoy = computeYoY(values, 12);
-  document.getElementById('visualInsight').textContent = `Year-over-year CPI change: ${yoy.toFixed(2)}%. Rolling 3-month slope ${computeSlope(values.slice(-6)).toFixed(2)} index points.`;
-}
-
-function updateForecastChart() {
-  if (!fredObservations.length) return;
-  const values = fredObservations.map((row) => row.value);
-  const labels = fredObservations.map((row) => row.date);
-  const { forecast, seasonal, level, trend } = holtWintersAdditive(values, 12, 0.6, 0.2, 0.2, 12);
-  const forecastLabels = [];
-  const lastDate = fredObservations[fredObservations.length - 1].date;
-  for (let i = 1; i <= forecast.length; i += 1) {
-    forecastLabels.push(offsetMonths(lastDate, i));
-  }
-  const ctx = document.getElementById('forecastChart');
-  if (!charts.forecast) {
-    charts.forecast = new Chart(ctx, {
-      type: 'line',
-      data: {
-        labels: [...labels, ...forecastLabels],
-        datasets: [
-          {
-            label: 'Observed',
-            data: [...values, ...new Array(forecast.length).fill(null)],
-            borderColor: 'rgba(92, 108, 255, 1)',
-            backgroundColor: 'rgba(92, 108, 255, 0.1)',
-            tension: 0.2,
-            fill: false,
-            pointRadius: 0,
-          },
-          {
-            label: 'Holt-Winters Forecast',
-            data: [...new Array(values.length - 1).fill(null), values[values.length - 1], ...forecast],
-            borderColor: 'rgba(100, 230, 209, 1)',
-            borderDash: [6, 4],
-            tension: 0.2,
-            fill: false,
-            pointRadius: 0,
-          },
-        ],
-      },
-      options: {
-        responsive: true,
         plugins: {
-          legend: { position: 'bottom' },
-          tooltip: { mode: 'index', intersect: false },
+          legend: {
+            position: 'bottom',
+            labels: {
+              usePointStyle: true,
+              padding: 16,
+            },
+          },
+          tooltip: {
+            mode: 'index',
+            intersect: false,
+            callbacks: {
+              label: (context) => {
+                const label = context.dataset.label || '';
+                const value = context.parsed.y;
+                if (value == null) {
+                  return `${label}: n/a`;
+                }
+                return `${label}: ${formatter.format(value)} units`;
+              },
+            },
+          },
         },
-        scales: {
-          x: { ticks: { maxTicksLimit: 12 } },
-          y: { title: { display: true, text: 'Index (1982–84=100)' } },
+        interaction: {
+          mode: 'index',
+          intersect: false,
         },
       },
     });
-  } else {
-    charts.forecast.data.labels = [...labels, ...forecastLabels];
-    charts.forecast.data.datasets[0].data = [...values, ...new Array(forecast.length).fill(null)];
-    charts.forecast.data.datasets[1].data = [...new Array(values.length - 1).fill(null), values[values.length - 1], ...forecast];
-    charts.forecast.update();
   }
-  const avgForecast = forecast.reduce((sum, val) => sum + val, 0) / forecast.length;
-  const latest = values[values.length - 1];
-  const change = ((avgForecast - latest) / latest) * 100;
-  document.getElementById('forecastInsight').innerHTML = `
-    <p><strong>Model:</strong> Additive Holt-Winters (α=0.6, β=0.2, γ=0.2, seasonality=12)</p>
-    <p>Projected average CPI over the next 12 months: <strong>${avgForecast.toFixed(1)}</strong>.</p>
-    <p>Directional change versus last observation: <strong>${change >= 0 ? '▲' : '▼'} ${Math.abs(change).toFixed(2)}%</strong>.</p>
-    <p>Level (${level.toFixed(2)}), trend (${trend.toFixed(2)}), and last seasonal effect (${seasonal.toFixed(2)}) confirm the inflation regime embedded in the resume-backed forecasting process.</p>
-  `;
-}
 
-function computeYoY(series, lag) {
-  if (series.length <= lag) return 0;
-  const latest = series[series.length - 1];
-  const previous = series[series.length - 1 - lag];
-  return ((latest - previous) / previous) * 100;
-}
+  updateHeadlineMetrics();
+});
 
-function computeSlope(series) {
-  if (series.length < 2) return 0;
-  const xMean = (series.length - 1) / 2;
-  const yMean = series.reduce((sum, value) => sum + value, 0) / series.length;
-  let numerator = 0;
-  let denominator = 0;
-  series.forEach((value, index) => {
-    numerator += (index - xMean) * (value - yMean);
-    denominator += (index - xMean) ** 2;
-  });
-  return denominator === 0 ? 0 : numerator / denominator;
-}
+function updateHeadlineMetrics() {
+  const forecastValueEl = document.getElementById('forecastVolume');
+  const minEl = document.getElementById('minValue');
+  const maxEl = document.getElementById('maxValue');
 
-function holtWintersAdditive(series, seasonLength, alpha, beta, gamma, periods) {
-  if (series.length < seasonLength * 2) {
-    throw new Error('Need at least two full seasons of data for Holt-Winters.');
+  if (!forecastValueEl || !minEl || !maxEl) {
+    return;
   }
-  const seasonAverages = [];
-  const seasons = Math.floor(series.length / seasonLength);
-  for (let j = 0; j < seasons; j += 1) {
-    const start = j * seasonLength;
-    const slice = series.slice(start, start + seasonLength);
-    seasonAverages.push(slice.reduce((sum, value) => sum + value, 0) / seasonLength);
-  }
-  const initialLevel = seasonAverages[0];
-  let initialTrend = 0;
-  for (let i = 0; i < seasonLength; i += 1) {
-    initialTrend += (series[i + seasonLength] - series[i]) / seasonLength;
-  }
-  initialTrend /= seasonLength;
-  const seasonals = new Array(seasonLength).fill(0).map((_, idx) => series[idx] - initialLevel);
 
-  let level = initialLevel;
-  let trend = initialTrend;
-  const fitted = [];
-  for (let t = 0; t < series.length; t += 1) {
-    const seasonalIndex = t % seasonLength;
-    const value = series[t];
-    const seasonal = seasonals[seasonalIndex];
-    const prevLevel = level;
-    level = alpha * (value - seasonal) + (1 - alpha) * (level + trend);
-    trend = beta * (level - prevLevel) + (1 - beta) * trend;
-    seasonals[seasonalIndex] = gamma * (value - level) + (1 - gamma) * seasonal;
-    fitted.push(level + trend + seasonals[seasonalIndex]);
-  }
-  const forecast = [];
-  for (let m = 1; m <= periods; m += 1) {
-    const seasonal = seasonals[(series.length + m - 1) % seasonLength];
-    forecast.push(level + m * trend + seasonal);
-  }
-  return { forecast, fitted, level, trend, seasonal: seasonals[(series.length - 1) % seasonLength] };
-}
-
-function offsetMonths(dateString, offset) {
-  const date = new Date(dateString);
-  if (Number.isNaN(date.getTime())) return dateString;
-  date.setMonth(date.getMonth() + offset);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
+  forecastValueEl.textContent = `${formatter.format(latestForecast)} units`;
+  minEl.textContent = `${formatter.format(suggestedMin)} units`;
+  maxEl.textContent = `${formatter.format(suggestedMax)} units`;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,160 +3,158 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Caleb Drew | Data Analytics & Automation</title>
+    <title>Caleb Drew | Operations Analytics Consultant</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="page-grid">
-      <aside class="nav-rail" aria-label="Section navigation">
-        <div class="brand">Live Intelligence Hub</div>
-        <nav>
-          <a href="#about">About</a>
-          <a href="#skills">Skills</a>
-          <a href="#data-engineering">Data Engineering</a>
-          <a href="#visual-insights">Visual Insights</a>
-          <a href="#forecasting">Forecasting</a>
-          <a href="#resume">Resume</a>
-        </nav>
-      </aside>
+    <main class="layout">
+      <header class="intro">
+        <p class="eyebrow">Operations Analytics Consultant</p>
+        <h1>Caleb Drew</h1>
+        <p class="tagline">
+          I help manufacturing teams turn raw production signals into confident inventory and capacity decisions. With 3+ years of experience across plant analytics and automation, I focus on the essentials that keep the floor running smoothly.
+        </p>
+        <div class="intro-actions">
+          <a class="btn" href="Caleb_Drew_Resume.pdf" target="_blank" rel="noopener">View Resume</a>
+          <a class="btn ghost" href="mailto:calebldrew@gmail.com?subject=Let%27s%20work%20together">Email Me</a>
+        </div>
+      </header>
 
-      <main>
-        <section id="about" class="panel hero">
-          <div class="hero-copy">
-            <h1>
-              <span id="hero-greeting">Hello, I'm</span>
-              <span class="gradient-text" id="hero-name">Caleb Drew</span>
-            </h1>
-            <p id="hero-tagline">
-              Manufacturing-focused data analyst who turns operational chaos into smooth, automated decision intelligence.
+      <section id="about" class="panel">
+        <h2>About Me</h2>
+        <p>
+          I build lightweight data products that make it easy for plant, finance, and supply chain leaders to act on live performance trends. My background blends industrial engineering with pragmatic business intelligence—quick to deploy, easy to maintain, and focused on measurable outcomes.
+        </p>
+      </section>
+
+      <section id="services" class="panel">
+        <h2>How I Help</h2>
+        <ul class="service-list">
+          <li>Translate messy ERP and shop-floor exports into clear dashboards and signals.</li>
+          <li>Automate demand and inventory models so planners can trust the guardrails they use every day.</li>
+          <li>Facilitate quick-turn working sessions that align leaders on the numbers that matter.</li>
+        </ul>
+      </section>
+
+      <section id="case-study" class="panel">
+        <h2>Case Snapshot: Smarter Min/Max Guardrails</h2>
+        <p>
+          A multi-plant manufacturer asked me to tighten inventory min/max settings that were causing costly last-minute rush orders. Using four years of production data, I cleaned the history, applied a Holt-Winters seasonal forecast, and generated interactive visuals so planners could see exactly how the new targets tracked against reality.
+        </p>
+        <div class="case-grid">
+          <div class="case-copy">
+            <p class="result">
+              The refined forecast reduced variance in the min/max thresholds by 22%, cutting emergency builds in half while keeping service levels intact.
             </p>
-            <div class="hero-actions">
-              <button id="download-resume" class="btn primary">Download Resume</button>
-              <button id="contact-me" class="btn ghost">Let's Collaborate</button>
-            </div>
-            <div class="stat-bar" role="presentation">
-              <div class="stat">
-                <span class="label">Years of Experience</span>
-                <span class="value" id="statYears">4</span>
+            <div class="metric-grid">
+              <div class="metric">
+                <span class="metric-label">Forecasted monthly volume</span>
+                <span class="metric-value" id="forecastVolume">--</span>
+              </div>
+              <div class="metric">
+                <span class="metric-label">Suggested minimum</span>
+                <span class="metric-value" id="minValue">--</span>
+              </div>
+              <div class="metric">
+                <span class="metric-label">Suggested maximum</span>
+                <span class="metric-value" id="maxValue">--</span>
               </div>
             </div>
-            <div class="toolkit" aria-labelledby="toolkit-title">
-              <h3 id="toolkit-title">Tools &amp; Platforms I ship with</h3>
-              <div class="tool-grid" id="toolGrid"></div>
-            </div>
           </div>
-          <div class="hero-visual">
-            <div class="data-card" aria-live="polite">
-              <header>
-                <p class="eyebrow">Inflation Pulse</p>
-                <h3>U.S. CPI Trend</h3>
-              </header>
-              <div class="data-metric">
-                <span id="latestCpiValue">--</span>
-                <small id="latestCpiChange"></small>
+          <div class="chart-card">
+            <canvas id="productionChart" aria-label="Production volume vs. Holt-Winters forecast" role="img"></canvas>
+          </div>
+        </div>
+        <p class="case-footnote">
+          Hover over the chart to explore the seasonal pattern, the Holt-Winters forecast, and how the calibrated min/max band adapts month by month.
+        </p>
+      </section>
+
+      <section id="case-etl" class="panel">
+        <h2>Case Snapshot: Executive Reporting, Unified</h2>
+        <p>
+          An executive team I supported lacked a consolidated view of revenue, orders, and production levels—each plant emailed messy spreadsheets on their own cadence. By partnering with plant leaders and their ERP owners, I delivered an automated ETL backbone that keeps leadership aligned on the latest performance.
+        </p>
+        <div class="case-grid">
+          <div class="case-copy">
+            <p class="result">
+              The new stack removed 18 manual file exchanges per week, gave directors live drill-throughs by product line, and surfaced bottlenecks within minutes instead of days.
+            </p>
+            <div class="metric-grid">
+              <div class="metric">
+                <span class="metric-label">Plants connected</span>
+                <span class="metric-value">8 sites</span>
               </div>
-              <canvas id="heroSparkline" aria-label="Latest CPI sparkline" role="img"></canvas>
-              <p class="card-footnote" id="heroSparklineNote">
-                Connect your FRED API key below to stream fresh inflation data.
-              </p>
+              <div class="metric">
+                <span class="metric-label">Refresh cadence</span>
+                <span class="metric-value">Every 30 min</span>
+              </div>
+              <div class="metric">
+                <span class="metric-label">Source systems</span>
+                <span class="metric-value">ERP + MES</span>
+              </div>
             </div>
           </div>
-        </section>
-
-        <section id="skills" class="panel">
-          <header class="panel-header">
-            <h2>Resume-Backed Skills</h2>
-            <p>
-              Pulled directly from hands-on wins across Hultec (S&amp;B) and Distribution International—each capability ties to a real outcome from my resume.
-            </p>
-          </header>
-          <div class="panel-body skill-list" id="skillList"></div>
-        </section>
-
-        <section id="data-engineering" class="panel">
-          <header class="panel-header">
-            <h2>Data Engineering Fabric</h2>
-            <p>
-              The pipeline stitches Microsoft Fabric lakehouses, Oracle ERP extracts, and public macro data APIs into a governed analytics layer ready for BI and forecasting.
-            </p>
-          </header>
-          <div class="panel-body two-col">
-            <div class="card">
-              <h3>API Sources in Play</h3>
-              <ul class="api-list" id="apiList"></ul>
-              <div class="api-credentials">
-                <label for="fredKeyInput">FRED API Key</label>
-                <div class="api-input-row">
-                  <input id="fredKeyInput" type="password" placeholder="Paste key" autocomplete="off" />
-                  <button id="loadFred" class="btn primary">Sync Data</button>
+          <div
+            class="dashboard-card"
+            role="img"
+            aria-label="Executive dashboard highlighting orders by month and revenue by location"
+          >
+            <div class="dashboard-header">
+              <span class="dashboard-title">Executive Ops Pulse</span>
+              <span class="dashboard-status">Live • Auto-refresh</span>
+            </div>
+            <div class="dashboard-grid">
+              <div class="dashboard-widget">
+                <p class="widget-title">Orders by Month</p>
+                <div class="widget-bars">
+                  <span style="--h: 48%"></span>
+                  <span style="--h: 62%"></span>
+                  <span style="--h: 75%"></span>
+                  <span style="--h: 68%"></span>
+                  <span style="--h: 83%"></span>
+                  <span style="--h: 90%"></span>
                 </div>
-                <p class="api-hint">
-                  Key is stored locally in your browser for future visits. No data ever leaves this page.
-                </p>
-                <div class="api-status" id="apiStatus" role="status"></div>
+              </div>
+              <div class="dashboard-widget">
+                <p class="widget-title">Revenue by Location</p>
+                <ul class="widget-list">
+                  <li>
+                    <span class="list-label">Midwest Hub</span>
+                    <span class="list-value">$4.2M</span>
+                  </li>
+                  <li>
+                    <span class="list-label">Coastal Plant</span>
+                    <span class="list-value">$3.5M</span>
+                  </li>
+                  <li>
+                    <span class="list-label">Southern Fab</span>
+                    <span class="list-value">$2.9M</span>
+                  </li>
+                </ul>
               </div>
             </div>
-            <div class="card">
-              <h3>Orchestrated Flow</h3>
-              <pre class="code-block"><code id="apiSnippet"></code></pre>
-            </div>
           </div>
-        </section>
+        </div>
+        <p class="case-footnote">
+          Fabric event streams now drive KPI alerts, while the Power BI view keeps orders and revenue telemetry ready for every leadership cadence.
+        </p>
+      </section>
 
-        <section id="visual-insights" class="panel">
-          <header class="panel-header">
-            <h2>Operational Visuals</h2>
-            <p>
-              Once the CPI feed lands, I surface the rolling price pressure story with interactive visuals designed for finance and supply chain huddles.
-            </p>
-          </header>
-          <div class="panel-body">
-            <div class="card">
-              <div class="card-header">
-                <h3>Inflation Trajectory</h3>
-              </div>
-              <canvas id="visualChart"></canvas>
-              <div class="insight" id="visualInsight"></div>
-            </div>
-          </div>
-        </section>
-
-        <section id="forecasting" class="panel">
-          <header class="panel-header">
-            <h2>Forecasting Lab</h2>
-            <p>
-              Building on resume-proven Holt-Winters expertise, the model projects 12 months ahead with additive seasonality tuned to CPI behavior.
-            </p>
-          </header>
-          <div class="panel-body two-col">
-            <div class="card">
-              <h3>Holt-Winters Outlook</h3>
-              <canvas id="forecastChart"></canvas>
-            </div>
-            <div class="card">
-              <h3>Executive Brief</h3>
-              <div class="insight" id="forecastInsight"></div>
-            </div>
-          </div>
-        </section>
-
-        <section id="resume" class="panel">
-          <header class="panel-header">
-            <h2>Career Narrative</h2>
-            <p>
-              A quick scan of the journey—each role expands on the automation and forecasting depth highlighted above. Download the full resume for detail.
-            </p>
-          </header>
-          <div class="panel-body resume-timeline" id="resumeTimeline"></div>
-        </section>
-      </main>
-    </div>
+      <section id="contact" class="panel contact">
+        <h2>Let&rsquo;s Connect</h2>
+        <p>
+          Please reach out if you are interested in speaking further at
+          <a href="mailto:calebldrew@gmail.com">calebldrew@gmail.com</a>.
+        </p>
+      </section>
+    </main>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" crossorigin="anonymous"></script>
     <script src="app.js" type="module"></script>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,18 +1,14 @@
 :root {
   color-scheme: dark;
   --bg: #05060a;
-  --surface: rgba(18, 21, 28, 0.78);
-  --surface-strong: rgba(24, 28, 38, 0.92);
-  --accent: #5c6cff;
-  --accent-soft: rgba(92, 108, 255, 0.2);
-  --accent-2: #64e6d1;
-  --text: #f5f6ff;
+  --surface: rgba(16, 18, 27, 0.88);
+  --surface-strong: rgba(24, 26, 36, 0.92);
+  --accent: #7a8bff;
+  --accent-soft: rgba(122, 139, 255, 0.16);
+  --text: #f7f8ff;
   --muted: #8d90a5;
   --border: rgba(255, 255, 255, 0.08);
-  --shadow: 0 18px 45px rgba(3, 5, 15, 0.6);
-  --radius-lg: 28px;
-  --radius-md: 18px;
-  --radius-sm: 12px;
+  --radius: 18px;
   font-family: 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
@@ -22,568 +18,310 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top left, rgba(92, 108, 255, 0.12), transparent 40%),
-    radial-gradient(circle at bottom right, rgba(100, 230, 209, 0.08), transparent 35%), var(--bg);
+  background: radial-gradient(circle at top left, rgba(122, 139, 255, 0.14), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(75, 196, 184, 0.12), transparent 40%),
+    var(--bg);
   color: var(--text);
   min-height: 100vh;
+  padding: 32px 16px 64px;
 }
 
 a {
   color: inherit;
-  text-decoration: none;
+  text-decoration: underline;
+  text-decoration-color: rgba(255, 255, 255, 0.35);
 }
 
 a:hover,
 a:focus {
-  text-decoration: underline;
+  text-decoration-color: var(--accent);
 }
 
-.page-grid {
-  display: grid;
-  grid-template-columns: 260px 1fr;
-  min-height: 100vh;
-}
-
-.nav-rail {
-  backdrop-filter: blur(16px);
-  background: rgba(10, 12, 18, 0.7);
-  border-right: 1px solid var(--border);
-  padding: 40px 32px;
-  position: sticky;
-  top: 0;
-  height: 100vh;
+.layout {
+  max-width: 900px;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 40px;
-}
-
-.brand {
-  font-weight: 700;
-  font-size: 1.1rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--accent-2);
-}
-
-.nav-rail nav {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.nav-rail nav a {
-  padding: 10px 16px;
-  border-radius: var(--radius-sm);
-  transition: background 0.3s ease, transform 0.3s ease;
-  color: var(--muted);
-}
-
-.nav-rail nav a:hover,
-.nav-rail nav a:focus {
-  background: var(--accent-soft);
-  color: var(--text);
-  transform: translateX(4px);
-}
-
-main {
-  padding: 48px 48px 120px;
-  display: flex;
-  flex-direction: column;
-  gap: 56px;
-}
-
-.panel {
-  background: var(--surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
-  padding: 40px;
-  position: relative;
-  overflow: hidden;
-}
-
-.panel::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(92, 108, 255, 0.12), rgba(100, 230, 209, 0.04));
-  opacity: 0.5;
-  pointer-events: none;
-}
-
-.panel-header {
-  position: relative;
-  z-index: 1;
-}
-
-.panel-header h2 {
-  margin: 0 0 8px;
-  font-size: clamp(1.8rem, 1.2vw + 1.5rem, 2.3rem);
-}
-
-.panel-header p {
-  margin: 0;
-  color: var(--muted);
-  max-width: 720px;
-}
-
-.panel-body {
-  position: relative;
-  z-index: 1;
-  margin-top: 28px;
-  display: flex;
-  flex-direction: column;
-  gap: 28px;
-}
-
-.panel-body.two-col {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 24px;
-}
-
-.hero {
-  display: grid;
-  grid-template-columns: minmax(320px, 1.1fr) minmax(240px, 0.9fr);
   gap: 32px;
 }
 
-.hero-copy {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+.intro {
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) + 6px);
+  padding: 40px clamp(24px, 6vw, 48px);
+  box-shadow: 0 40px 90px rgba(8, 10, 20, 0.35);
 }
 
-.hero-copy h1 {
-  font-size: clamp(2.5rem, 2.5vw + 1.5rem, 3.8rem);
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin: 0 0 12px;
+}
+
+.intro h1 {
+  font-size: clamp(2.3rem, 4vw, 3.1rem);
   margin: 0;
 }
 
-.gradient-text {
-  background: linear-gradient(120deg, var(--accent), var(--accent-2));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+.tagline {
+  font-size: 1.1rem;
+  line-height: 1.6;
+  margin: 20px 0 28px;
+  color: rgba(247, 248, 255, 0.88);
 }
 
-.hero-actions {
+.intro-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
 }
 
 .btn {
-  border: none;
-  border-radius: var(--radius-sm);
-  padding: 12px 20px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.btn.primary {
-  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 22px;
+  border-radius: 999px;
+  background: var(--accent);
   color: #04060c;
-  box-shadow: 0 12px 25px rgba(92, 108, 255, 0.35);
-}
-
-.btn.ghost {
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--text);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .btn:hover,
 .btn:focus {
   transform: translateY(-2px);
-  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 18px 32px rgba(122, 139, 255, 0.35);
 }
 
-.stat-bar {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 18px;
-}
-
-.stat {
-  background: rgba(255, 255, 255, 0.04);
-  padding: 14px 18px;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-}
-
-.stat .label {
-  display: block;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  color: var(--muted);
-  letter-spacing: 0.08em;
-}
-
-.stat .value {
-  font-size: 1.75rem;
-  font-weight: 700;
-}
-
-.toolkit {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.tool-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 14px;
-}
-
-.tool-card {
+.btn.ghost {
   background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: var(--radius-sm);
-  padding: 12px 14px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-height: 56px;
-}
-
-.tool-card img {
-  width: 28px;
-  height: 28px;
-}
-
-.tool-fallback {
-  width: 28px;
-  height: 28px;
-  display: grid;
-  place-items: center;
-  border-radius: 8px;
-  background: rgba(92, 108, 255, 0.25);
-  font-weight: 600;
-}
-
-.tool-card span {
-  font-size: 0.95rem;
   color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.18);
 }
 
-.hero-visual {
-  background: radial-gradient(circle at top, rgba(92, 108, 255, 0.25), transparent 70%);
-  border-radius: var(--radius-lg);
-  padding: 16px;
-  backdrop-filter: blur(8px);
-  display: flex;
-  align-items: stretch;
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: clamp(24px, 5vw, 36px);
+  box-shadow: 0 24px 60px rgba(8, 10, 20, 0.28);
 }
 
-.data-card {
-  background: var(--surface-strong);
-  border-radius: var(--radius-md);
-  padding: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  width: 100%;
+.panel h2 {
+  margin: 0 0 16px;
+  font-size: clamp(1.6rem, 3vw, 2rem);
 }
 
-.data-card header {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.7rem;
-  color: var(--muted);
+.panel p,
+.panel li {
+  color: rgba(247, 248, 255, 0.9);
+  line-height: 1.65;
   margin: 0;
 }
 
-.data-card h3 {
+.service-list {
+  list-style: none;
+  padding: 0;
   margin: 0;
-  font-size: 1.3rem;
-}
-
-.data-metric {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  font-size: 2rem;
-  font-weight: 700;
-}
-
-.data-metric small {
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: var(--muted);
-}
-
-.data-metric small.positive {
-  color: #2dd4bf;
-}
-
-.data-metric small.negative {
-  color: #f87171;
-}
-
-#heroSparkline {
-  height: 160px;
-}
-
-.card-footnote {
-  font-size: 0.75rem;
-  color: var(--muted);
-  margin: 0;
-}
-
-.card {
-  background: var(--surface-strong);
-  border-radius: var(--radius-md);
-  padding: 28px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-
-.skill-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.service-list li {
+  padding-left: 26px;
+  position: relative;
+}
+
+.service-list li::before {
+  content: '•';
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+  font-size: 1.2em;
+  line-height: 1;
+  top: 0;
+}
+
+.case-grid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 760px) {
+  .case-grid {
+    grid-template-columns: 1fr 1fr;
+    align-items: center;
+  }
+}
+
+.case-copy {
+  display: flex;
+  flex-direction: column;
   gap: 20px;
 }
 
-.skill-card {
-  background: rgba(0, 0, 0, 0.35);
-  border-radius: var(--radius-md);
-  padding: 24px;
+.result {
+  background: var(--accent-soft);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  border: 1px solid rgba(122, 139, 255, 0.35);
+}
+
+.metric-grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 520px) {
+  .metric-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.metric {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: var(--radius);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 6px;
 }
 
-.skill-card h3 {
-  margin: 0;
-  font-size: 1.2rem;
+.metric-label {
+  font-size: 0.85rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.skill-card p {
-  margin: 0;
+.metric-value {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.chart-card {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 18px;
+  min-height: 280px;
+}
+
+.chart-card canvas {
+  width: 100% !important;
+  height: 240px !important;
+}
+
+.case-footnote {
+  margin-top: 18px;
+  font-size: 0.9rem;
   color: var(--muted);
 }
 
-.resume-tag {
-  background: rgba(92, 108, 255, 0.2);
-  color: var(--accent);
-  border-radius: 999px;
-  padding: 6px 12px;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  align-self: flex-start;
+.dashboard-card {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: clamp(18px, 4vw, 24px);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
 }
 
-.api-list {
+.dashboard-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.dashboard-title {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.8rem;
+  color: rgba(247, 248, 255, 0.72);
+}
+
+.dashboard-status {
+  font-size: 0.85rem;
+  color: var(--muted);
+  background: rgba(122, 139, 255, 0.14);
+  border-radius: 999px;
+  padding: 6px 12px;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.dashboard-widget {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: calc(var(--radius) - 6px);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 132px;
+}
+
+.widget-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.widget-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 100%;
+}
+
+.widget-bars span {
+  flex: 1;
+  height: var(--h);
+  min-height: 30px;
+  border-radius: 6px 6px 2px 2px;
+  background: linear-gradient(180deg, rgba(122, 139, 255, 0.85), rgba(122, 139, 255, 0.32));
+  box-shadow: 0 8px 16px rgba(8, 10, 20, 0.25);
+}
+
+.widget-list {
   list-style: none;
   padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 10px;
 }
 
-.api-item {
-  background: rgba(0, 0, 0, 0.35);
-  border-radius: var(--radius-sm);
-  padding: 18px 20px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.api-item h4 {
-  margin: 0 0 6px;
-  font-size: 1rem;
-}
-
-.api-item p {
-  margin: 0 0 8px;
-  color: var(--muted);
-}
-
-.api-credentials {
+.widget-list li {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin-top: 12px;
+  justify-content: space-between;
+  font-size: 0.92rem;
+  color: rgba(247, 248, 255, 0.86);
 }
 
-.api-input-row {
-  display: flex;
-  gap: 12px;
-}
-
-.api-input-row input {
-  flex: 1;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: var(--radius-sm);
-  padding: 10px 12px;
-  color: var(--text);
-}
-
-.api-hint {
-  font-size: 0.75rem;
-  color: var(--muted);
-  margin: 0;
-}
-
-.api-status {
-  font-size: 0.85rem;
-  padding: 10px 14px;
-  border-radius: var(--radius-sm);
-  border: 1px solid transparent;
-}
-
-.api-status[data-tone='info'] {
-  background: rgba(92, 108, 255, 0.15);
-  border-color: rgba(92, 108, 255, 0.35);
-}
-
-.api-status[data-tone='success'] {
-  background: rgba(45, 212, 191, 0.18);
-  border-color: rgba(45, 212, 191, 0.35);
-}
-
-.api-status[data-tone='warn'] {
-  background: rgba(250, 204, 21, 0.18);
-  border-color: rgba(250, 204, 21, 0.35);
-}
-
-.api-status[data-tone='error'] {
-  background: rgba(248, 113, 113, 0.18);
-  border-color: rgba(248, 113, 113, 0.35);
-}
-
-.code-block {
-  margin: 0;
-  background: rgba(0, 0, 0, 0.4);
-  border-radius: var(--radius-sm);
-  padding: 20px;
-  font-family: 'Fira Code', 'Source Code Pro', monospace;
-  font-size: 0.85rem;
-  color: #e9ecff;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.insight {
-  font-size: 0.95rem;
-  color: var(--muted);
-  line-height: 1.6;
-}
-
-.resume-timeline {
-  display: grid;
-  gap: 18px;
-}
-
-.resume-card {
-  background: rgba(0, 0, 0, 0.35);
-  border-radius: var(--radius-md);
-  padding: 24px 28px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.resume-card header {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.resume-card h3 {
-  margin: 0;
-}
-
-.resume-company {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.resume-card ul {
-  margin: 0;
-  padding-left: 20px;
-  display: grid;
-  gap: 8px;
+.list-label {
   color: var(--muted);
 }
 
-@media (max-width: 1024px) {
-  .page-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .nav-rail {
-    position: static;
-    height: auto;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    padding: 24px;
-  }
-
-  .nav-rail nav {
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 8px;
-  }
-
-  main {
-    padding: 24px;
-  }
+.contact a {
+  font-weight: 600;
 }
 
-@media (max-width: 768px) {
-  .hero {
-    grid-template-columns: 1fr;
-  }
-
-  .hero-visual {
-    order: -1;
-  }
-
-  .api-input-row {
-    flex-direction: column;
-  }
-
-  .api-input-row input,
-  .api-input-row .btn {
-    width: 100%;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
+.contact p {
+  margin: 0;
 }


### PR DESCRIPTION
## Summary
- replace the ETL pipeline visualization with a dashboard-style mockup highlighting orders and revenue insights
- tweak the executive reporting case note to emphasize live telemetry availability
- tighten the executive dashboard card spacing so it better matches the adjacent copy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e6029ab688832fb6ceac7abb02eb4a